### PR TITLE
Don't require sudo: true for travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ optional arguments:
 
 ```
 before_install:
-  - sudo luarocks install luacov-coveralls
+  - luarocks install --local luacov-coveralls
 
 script:
-  - lua -lluacov test.lua
+  - LUA_PATH="?;?.lua;$HOME/.luarocks/share/lua/5.1/?.lua" lua -lluacov test.lua
 
 after_success:
-  - luacov-coveralls
+  - $HOME/.luarocks/bin/luacov-coveralls
 ```
 
 ###Test Lua module written on Lua and C using [cpp-coveralls](https://github.com/eddyxu/cpp-coveralls)


### PR DESCRIPTION
Partially a PR, partially a RFC.

Requiring sudo on travis means you have to use a different set of VMs which are slower and have a longer wait time.

This way does [work](https://github.com/ClearTables/ClearTables/blob/master/.travis.yml) but I'm not sure it's the best. In particular, I don't know if there's a better way to do the LUA_PATH
