### PR TITLE
Expand Gitlab CI support to recognize pipelines and merge requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LuaCov reporter for [coveralls.io](https://coveralls.io) service.
 Currently support 
   * [Travis CI](https://travis-ci.org)
   * [AppVeyor](https://appveyor.com)
+  * [GitLab](https://gitlab.com) (or self-hosted)
 
 Also `luacov-coveralls` has code which support some other CI but I never test them.
 If you can test it please do that and send PR.

--- a/src/luacov/coveralls/CiInfo.lua
+++ b/src/luacov/coveralls/CiInfo.lua
@@ -84,8 +84,8 @@ local CI_CONFIG = {
 
   gitlab = {
     branch          = "CI_COMMIT_REF_NAME";
-    service_number  = NULL;
-    pull_request    = NULL;
+    service_number  = "CI_PIPELINE_ID";
+    pull_request    = "CI_MERGE_REQUEST_ID";
     job_id          = "CI_JOB_ID";
     token           = "COVERALLS_REPO_TOKEN";
     commit_id       = "CI_COMMIT_SHA";


### PR DESCRIPTION
This is supplemental to #13 and should be merged first, which will put this code  into the `gitlab_ci` branch so that PR will include these values.