### PR TITLE
Add Gitlab Actions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently support
   * [Travis CI](https://travis-ci.org)
   * [AppVeyor](https://appveyor.com)
   * [GitLab](https://gitlab.com) (or self-hosted)
+  * [GitHub Actions](https://github.com/features/actions)
 
 Also `luacov-coveralls` has code which support some other CI but I never test them.
 If you can test it please do that and send PR.

--- a/src/luacov/coveralls/CiInfo.lua
+++ b/src/luacov/coveralls/CiInfo.lua
@@ -96,10 +96,25 @@ local CI_CONFIG = {
     message         = "CI_COMMIT_TITLE";
   };
 
+  actions = {
+    branch          = "GITHUB_REF";
+    service_number  = NULL;
+    pull_request    = NULL;
+    job_id          = "RUNNER_TRACKING_ID";
+    token           = "COVERALLS_REPO_TOKEN";
+    commit_id       = "GITHUB_SHA";
+    author_name     = NULL;
+    author_email    = NULL;
+    committer_name  = NULL;
+    committer_email = NULL;
+    message         = NULL;
+  };
+
 }
 
 local function is_ci()
-  return ENV.CI and ENV.CI:lower() == "true"
+  local CIVAR = ENV.CI or ENV.GITHUB_ACTIONS
+  return CIVAR and CIVAR:lower() == "true"
 end
 
 local function ci_name()
@@ -111,6 +126,7 @@ local function ci_name()
   if (ENV.APPVEYOR  or ''):lower() == "true"     then return "appveyor"  end
   if (ENV.DRONE     or ''):lower() == "true"     then return "drone"     end
   if (ENV.GITLAB_CI or ''):lower() == "true"     then return "gitlab"    end
+  if (ENV.GITHUB_ACTIONS or ''):lower() == "true" then return "actions"  end
 end
 
 local function cfg()


### PR DESCRIPTION
Closes #17.

This adds support for Github Actions. It almost works, as seen [here](https://github.com/alerque/luacov-coveralls/commit/d1a74fe2e834adebd87ee50baf0548b40a89ca95/checks#step:8:55), but not quite.

I'm guessing the issue is that Coveralls doesn't like the branch we're passing? The relevant `env` variable has `refs/heads/master` and if I don't use the env at all and let the script try to guess all it can come up with is `HEAD`.

----

I'm marking this as a draft PR to document the status and get feedback. After it works I'll remove the CI config script and leave just the additions to this project's code, then mark it as ready for review.

(Note this PR is from my master branch because Actions doesn't run on other branches unless the master branch enables the jobs.)