### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/rockspecs/luacov-coveralls-0.1.0-2.rockspec
+++ b/rockspecs/luacov-coveralls-0.1.0-2.rockspec
@@ -1,8 +1,8 @@
 package = "LuaCov-coveralls"
-version = "scm-0"
+version = "0.1.0-2"
 source = {
    url = "git+https://github.com/moteus/luacov-coveralls",
-   tag = "master"
+   tag = "v0.1.0"
 }
 description = {
    summary = "LuaCov reporter for coveralls.io service",
@@ -14,8 +14,7 @@ description = {
 dependencies = {
    "lua >= 5.1",
    -- "luajson",
-   -- "lua-cjson",
-   "dkjson",
+   "lua-cjson",
    "luacov > 0.5",
    "luafilesystem",
    "lua-path",
@@ -24,12 +23,10 @@ build = {
    type = "builtin",
    copy_directories = {},
    modules = {
-      ['luacov.reporter.coveralls'      ] = "src/luacov/reporter/coveralls.lua",
-      ['luacov.coveralls.CiInfo'        ] = "src/luacov/coveralls/CiInfo.lua",
-      ['luacov.coveralls.CiRepo'        ] = "src/luacov/coveralls/CiRepo.lua",
-      ['luacov.coveralls.utils'         ] = "src/luacov/coveralls/utils.lua",
-      ['luacov.coveralls.repo.appveyor' ] = "src/luacov/coveralls/repo/appveyor.lua",
-      ['luacov.coveralls.repo.git'      ] = "src/luacov/coveralls/repo/git.lua",
+      ['luacov.reporter.coveralls'] = "src/luacov/reporter/coveralls.lua",
+      ['luacov.coveralls.GitRepo' ] = "src/luacov/coveralls/GitRepo.lua",
+      ['luacov.coveralls.CiInfo'  ] = "src/luacov/coveralls/CiInfo.lua",
+      ['luacov.coveralls.utils'   ] = "src/luacov/coveralls/utils.lua",
    },
    install = {
       bin = {

--- a/rockspecs/luacov-coveralls-0.1.1-2.rockspec
+++ b/rockspecs/luacov-coveralls-0.1.1-2.rockspec
@@ -1,8 +1,8 @@
 package = "LuaCov-coveralls"
-version = "scm-0"
+version = "0.1.1-2"
 source = {
    url = "git+https://github.com/moteus/luacov-coveralls",
-   tag = "master"
+   tag = "v0.1.1"
 }
 description = {
    summary = "LuaCov reporter for coveralls.io service",
@@ -14,8 +14,7 @@ description = {
 dependencies = {
    "lua >= 5.1",
    -- "luajson",
-   -- "lua-cjson",
-   "dkjson",
+   "lua-cjson",
    "luacov > 0.5",
    "luafilesystem",
    "lua-path",
@@ -24,12 +23,11 @@ build = {
    type = "builtin",
    copy_directories = {},
    modules = {
-      ['luacov.reporter.coveralls'      ] = "src/luacov/reporter/coveralls.lua",
-      ['luacov.coveralls.CiInfo'        ] = "src/luacov/coveralls/CiInfo.lua",
-      ['luacov.coveralls.CiRepo'        ] = "src/luacov/coveralls/CiRepo.lua",
-      ['luacov.coveralls.utils'         ] = "src/luacov/coveralls/utils.lua",
-      ['luacov.coveralls.repo.appveyor' ] = "src/luacov/coveralls/repo/appveyor.lua",
-      ['luacov.coveralls.repo.git'      ] = "src/luacov/coveralls/repo/git.lua",
+      ['luacov.reporter.coveralls'] = "src/luacov/reporter/coveralls.lua",
+      ['luacov.coveralls.GitRepo' ] = "src/luacov/coveralls/GitRepo.lua",
+      ['luacov.coveralls.CiInfo'  ] = "src/luacov/coveralls/CiInfo.lua",
+      ['luacov.coveralls.CiRepo'  ] = "src/luacov/coveralls/CiRepo.lua",
+      ['luacov.coveralls.utils'   ] = "src/luacov/coveralls/utils.lua",
    },
    install = {
       bin = {

--- a/rockspecs/luacov-coveralls-0.2.0-2.rockspec
+++ b/rockspecs/luacov-coveralls-0.2.0-2.rockspec
@@ -1,8 +1,8 @@
 package = "LuaCov-coveralls"
-version = "scm-0"
+version = "0.2.0-2"
 source = {
    url = "git+https://github.com/moteus/luacov-coveralls",
-   tag = "master"
+   tag = "v0.2.0"
 }
 description = {
    summary = "LuaCov reporter for coveralls.io service",

--- a/rockspecs/luacov-coveralls-0.2.1-2.rockspec
+++ b/rockspecs/luacov-coveralls-0.2.1-2.rockspec
@@ -1,8 +1,8 @@
 package = "LuaCov-coveralls"
-version = "scm-0"
+version = "0.2.1-2"
 source = {
    url = "git+https://github.com/moteus/luacov-coveralls",
-   tag = "master"
+   tag = "v0.2.1"
 }
 description = {
    summary = "LuaCov reporter for coveralls.io service",

--- a/rockspecs/luacov-coveralls-0.2.2-2.rockspec
+++ b/rockspecs/luacov-coveralls-0.2.2-2.rockspec
@@ -1,8 +1,8 @@
 package = "LuaCov-coveralls"
-version = "scm-0"
+version = "0.2.2-2"
 source = {
    url = "git+https://github.com/moteus/luacov-coveralls",
-   tag = "master"
+   tag = "v0.2.2"
 }
 description = {
    summary = "LuaCov reporter for coveralls.io service",

--- a/rockspecs/luacov-coveralls-0.2.3-2.rockspec
+++ b/rockspecs/luacov-coveralls-0.2.3-2.rockspec
@@ -1,8 +1,8 @@
 package = "LuaCov-coveralls"
-version = "scm-0"
+version = "0.2.3-2"
 source = {
    url = "git+https://github.com/moteus/luacov-coveralls",
-   tag = "master"
+   tag = "v0.2.3"
 }
 description = {
    summary = "LuaCov reporter for coveralls.io service",


### PR DESCRIPTION
GitHub disables unencrypted Git protocol, so `git://` URLs stop working now (see https://github.blog/2021-09-01-improving-git-protocol-security-github/).

luarocks 3.8.0 autoconverts `git://` URLs into `git+https://` ones (see https://github.com/luarocks/luarocks/commit/9ff512e35455939f02eaec2318e3acc77782fdeb), but there is plenty large community of users that still use one of previous luarocks version.

Since a distro package verifies a released rockspec with checksums, bumped revisions for them. Technically I had copied an X.Y.Z-1 rockspec into the X.Y.Z-2 one and apply a change like the following:

```diff
--- rockspecs/luacov-coveralls-0.2.3-1.rockspec
+++ rockspecs/luacov-coveralls-0.2.3-2.rockspec
@@ -1,7 +1,7 @@
 package = "LuaCov-coveralls"
-version = "0.2.3-1"
+version = "0.2.3-2"
 source = { 
-   url = "git://github.com/moteus/luacov-coveralls",
+   url = "git+https://github.com/moteus/luacov-coveralls",
    tag = "v0.2.3"
 }
 description = { 
```

The scm-0 rockspec is updated in place.